### PR TITLE
ADD #none_of

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ActiverecordAnyOf
 
-This method is inspired by [any_of from mongoid](http://two.mongoid.org/docs/querying/criteria.html#any_of).
+This gem provides `#any_of` and `#none_of` on ActiveRecord.
+
+`#any_of` is inspired by [any_of from mongoid](http://two.mongoid.org/docs/querying/criteria.html#any_of).
 
 It allows to compute an `OR` like query that leverages AR's `#where` syntax:
 
@@ -23,6 +25,14 @@ Its main purpose is to both :
 
 * remove the need to write a sql string when we want an `OR`
 * allows to write dynamic `OR` queries, which would be a pain with a string
+
+`#none_of` is the negative version of `#any_of`. This will return all active users :
+
+```ruby
+banned_users = User.where(banned: true)
+unconfirmed_users = User.where("confirmed_at IS NULL")
+active_users = User.none_of(banned_users, unconfirmed_users)
+```
 
 
 ## Installation

--- a/lib/activerecord_any_of/alternative_builder.rb
+++ b/lib/activerecord_any_of/alternative_builder.rb
@@ -1,0 +1,99 @@
+module ActiverecordAnyOf
+  class AlternativeBuilder
+    def initialize(match_type, context, *queries)
+      @builder = match_type == :negative ? NegativeBuilder.new(context, *queries) : PositiveBuilder.new(context, *queries)
+    end
+
+    def build
+      @builder.build
+    end
+
+    class Builder
+      attr_accessor :queries_bind_values, :queries_joins_values
+
+      def initialize(context, *source_queries)
+        @context, @source_queries = context, source_queries
+        @queries_bind_values, @queries_joins_values = [], { includes: [],  joins: [], references: [] }
+      end
+
+      def build
+        ActiveRecord::Base.connection.supports_statement_cache? ? with_statement_cache : without_statement_cache
+      end
+
+      private
+
+        def queries
+          @queries ||= @source_queries.map do |query|
+            query = where(query) if [String, Hash].any? { |type| query.kind_of?(type) }
+            query = where(*query) if query.kind_of?(Array)
+            self.queries_bind_values += query.bind_values if query.bind_values.any?
+            queries_joins_values[:includes] += query.includes_values if query.includes_values.any?
+            queries_joins_values[:joins] += query.joins_values if query.joins_values.any?
+            queries_joins_values[:references] += query.references_values if Rails.version >= '4' && query.references_values.any?
+            query.arel.constraints.reduce(:and)
+          end
+        end
+
+        def uniq_queries_joins_values
+          @uniq_queries_joins_values ||= queries_joins_values.each { |tables| tables.uniq }
+        end
+
+        def method_missing(method_name, *args, &block)
+          @context.send(method_name, *args, &block)
+        end
+
+        def add_joins_to( relation )
+          relation = relation.references(uniq_queries_joins_values[:references]) if Rails.version >= '4'
+          relation = relation.includes(uniq_queries_joins_values[:includes])
+          relation.joins(uniq_queries_joins_values[:joins])
+        end
+
+        def add_related_values_to( relation )
+          relation.bind_values += queries_bind_values
+          relation.includes_values += uniq_queries_joins_values[:includes]
+          relation.joins_values += uniq_queries_joins_values[:joins]
+          relation.references_values += uniq_queries_joins_values[:references] if Rails.version >= '4'
+
+          relation
+        end
+    end
+
+    class PositiveBuilder < Builder
+      private
+
+        def with_statement_cache
+          relation = where([queries.reduce(:or).to_sql, *queries_bind_values.map { |v| v[1] }])
+          add_joins_to relation
+        end
+
+        def without_statement_cache
+          relation = where(queries.reduce(:or))
+          add_related_values_to relation
+        end
+    end
+
+    class NegativeBuilder < Builder
+      private
+
+        def with_statement_cache
+          if Rails.version >= '4'
+            relation = where.not([queries.reduce(:or).to_sql, *queries_bind_values.map { |v| v[1] }])
+          else
+            relation = where([Arel::Nodes::Not.new(queries.reduce(:or)).to_sql, *queries_bind_values.map { |v| v[1] }])
+          end
+
+          add_joins_to relation
+        end
+
+        def without_statement_cache
+          if Rails.version >= '4'
+            relation = where.not(queries.reduce(:or))
+          else
+            relation = where(Arel::Nodes::Not.new(queries.reduce(:or)))
+          end
+
+          add_related_values_to relation
+        end
+    end
+  end
+end

--- a/test/activerecord_any_of_test.rb
+++ b/test/activerecord_any_of_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'pry-debugger'
 
 class ActiverecordAnyOfTest < ActiveSupport::TestCase
   fixtures :authors, :posts
@@ -26,7 +25,7 @@ class ActiverecordAnyOfTest < ActiveSupport::TestCase
     assert_equal expected, david.posts.any_of(welcome, {type: 'SpecialPost'}).map(&:title)
   end
 
-  def test_finding_alternate_dynamically_with_joined_queries
+  test 'finding alternate dynamically with joined queries' do
     david = Author.where(posts: { title: 'Welcome to the weblog' }).joins(:posts)
     mary = Author.where(posts: { title: "eager loading with OR'd conditions" }).joins(:posts)
 
@@ -41,5 +40,16 @@ class ActiverecordAnyOfTest < ActiveSupport::TestCase
     end
 
     assert_equal ['David', 'Mary'], Author.any_of(david, mary).map(&:name)
+  end
+
+  test 'finding with alternate negative conditions' do
+    assert_equal ['Bob'], Author.none_of({name: 'David'}, {name: 'Mary'}).map(&:name)
+  end
+
+  test 'finding with alternate negative conditions on association' do
+    david = Author.where(name: 'David').first
+    welcome = david.posts.where(body: 'Such a lovely day')
+    expected = ['sti comments', 'sti me', 'habtm sti test']
+    assert_equal expected, david.posts.none_of(welcome, {type: 'SpecialPost'}).map(&:title)
   end
 end


### PR DESCRIPTION
`#none_of` is the negative version of `#any_of`. This will return all
active users :

``` ruby
banned_users = User.where(banned: true)
unconfirmed_users = User.where("confirmed_at IS NULL")
active_users = User.none_of(banned_users, unconfirmed_users)
```
