### PR TITLE
REFACTOR raise exception when no arguments

### DIFF
--- a/lib/activerecord_any_of.rb
+++ b/lib/activerecord_any_of.rb
@@ -23,6 +23,7 @@ module ActiverecordAnyOf
   #    unconfirmed_users = User.where("confirmed_at IS NULL")
   #    unactive_users = User.any_of(banned_users, unconfirmed_users)
   def any_of(*queries)
+    raise ArgumentError, 'Called any_of() with no arguments.' if queries.none?
     AlternativeBuilder.new(:positive, self, *queries).build
   end
 
@@ -35,6 +36,7 @@ module ActiverecordAnyOf
   #    unconfirmed_users = User.where("confirmed_at IS NULL")
   #    active_users = User.none_of(banned_users, unconfirmed_users)
   def none_of(*queries)
+    raise ArgumentError, 'Called none_of() with no arguments.' if queries.none?
     AlternativeBuilder.new(:negative, self, *queries).build
   end
 end

--- a/test/activerecord_any_of_test.rb
+++ b/test/activerecord_any_of_test.rb
@@ -52,4 +52,12 @@ class ActiverecordAnyOfTest < ActiveSupport::TestCase
     expected = ['sti comments', 'sti me', 'habtm sti test']
     assert_equal expected, david.posts.none_of(welcome, {type: 'SpecialPost'}).map(&:title)
   end
+
+  test 'calling #any_of with no argument raise exception' do
+    assert_raise(ArgumentError) { Author.any_of }
+  end
+
+  test 'calling #none_of with no argument raise exception' do
+    assert_raise(ArgumentError) { Author.none_of }
+  end
 end


### PR DESCRIPTION
Raise an ArgumentError if `#any_of` or `#none_of` are called without any
argument.

Close #2
