### PR TITLE
REFACTOR use WhereChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,17 @@ This gem provides `#any_of` and `#none_of` on ActiveRecord.
 It allows to compute an `OR` like query that leverages AR's `#where` syntax:
 
 ```ruby
-users = User.any_of("email like '%@example.com'", {banned: true}).destroy_all
+users = User.where.any_of("email like '%@example.com'", {banned: true}).destroy_all
 # DELETE FROM users WHERE email LIKE '%@example.com' OR banned = '1';
 ```
 
-It can be used directly on model class, or through an association, or
-behind an other relation.
+It can be used anywhere `#where` is valid :
 
 ```ruby
 manual_removal = User.where(id: params[:users][:destroy_ids])
-User.any_of(manual_removal, "email like '%@example.com'", {banned: true})
-@company.users.any_of(manual_removal, "email like '%@example.com'", {banned: true})
-User.where(offline: false).any_of( manual_removal, "email like '%@example.com'", {banned: true})
+User.where.any_of(manual_removal, "email like '%@example.com'", {banned: true})
+@company.users.where.any_of(manual_removal, "email like '%@example.com'", {banned: true})
+User.where(offline: false).where.any_of( manual_removal, "email like '%@example.com'", {banned: true})
 ```
 
 Its main purpose is to both :
@@ -31,9 +30,20 @@ Its main purpose is to both :
 ```ruby
 banned_users = User.where(banned: true)
 unconfirmed_users = User.where("confirmed_at IS NULL")
-active_users = User.none_of(banned_users, unconfirmed_users)
+active_users = User.where.none_of(banned_users, unconfirmed_users)
 ```
 
+## Rails-3
+
+`activerecord_any_of` uses WhereChain, which has been introduced in rails-4. In
+rails-3, simply call `#any_of` and `#none_of` directly, without using `#where` :
+
+```ruby
+manual_removal = User.where(id: params[:users][:destroy_ids])
+User.any_of(manual_removal, "email like '%@example.com'", {banned: true})
+@company.users.any_of(manual_removal, "email like '%@example.com'", {banned: true})
+User.where(offline: false).any_of( manual_removal, "email like '%@example.com'", {banned: true})
+```
 
 ## Installation
 

--- a/lib/activerecord_any_of.rb
+++ b/lib/activerecord_any_of.rb
@@ -1,43 +1,65 @@
 require 'activerecord_any_of/alternative_builder'
 
 module ActiverecordAnyOf
-  # Returns a new relation, which includes results matching any of the conditions
-  # passed as parameters. You can think of it as a sql <tt>OR</tt> implementation.
-  #
-  # Each #any_of parameter is the same set you would have passed to #where :
-  #
-  #    Client.any_of("orders_count = '2'", ["name = ?", 'Joe'], {email: 'joe@example.com'})
-  #
-  # You can as well pass #any_of to other relations :
-  #
-  #    Client.where("orders_count = '2'").any_of({ email: 'joe@example.com' }, { email: 'john@example.com' })
-  #
-  # And with associations :
-  #
-  #    User.find(1).posts.any_of({published: false}, "user_id IS NULL")
-  #
-  # The best part is that #any_of accepts other relations as parameter, to help compute
-  # dynamic <tt>OR</tt> queries :
-  #
-  #    banned_users = User.where(banned: true)
-  #    unconfirmed_users = User.where("confirmed_at IS NULL")
-  #    inactive_users = User.any_of(banned_users, unconfirmed_users)
-  def any_of(*queries)
-    raise ArgumentError, 'Called any_of() with no arguments.' if queries.none?
-    AlternativeBuilder.new(:positive, self, *queries).build
+  module Chained
+    # Returns a new relation, which includes results matching any of the conditions
+    # passed as parameters. You can think of it as a sql <tt>OR</tt> implementation.
+    #
+    # Each #any_of parameter is the same set you would have passed to #where :
+    #
+    #    Client.any_of("orders_count = '2'", ["name = ?", 'Joe'], {email: 'joe@example.com'})
+    #
+    # You can as well pass #any_of to other relations :
+    #
+    #    Client.where("orders_count = '2'").any_of({ email: 'joe@example.com' }, { email: 'john@example.com' })
+    #
+    # And with associations :
+    #
+    #    User.find(1).posts.any_of({published: false}, "user_id IS NULL")
+    #
+    # The best part is that #any_of accepts other relations as parameter, to help compute
+    # dynamic <tt>OR</tt> queries :
+    #
+    #    banned_users = User.where(banned: true)
+    #    unconfirmed_users = User.where("confirmed_at IS NULL")
+    #    inactive_users = User.any_of(banned_users, unconfirmed_users)
+    def any_of(*queries)
+      raise ArgumentError, 'Called any_of() with no arguments.' if queries.none?
+      AlternativeBuilder.new(:positive, @scope, *queries).build
+    end
+
+    # Returns a new relation, which includes results not matching any of the conditions
+    # passed as parameters. It's the negative version of <tt>#any_of</tt>.
+    #
+    # This will return all active users :
+    #
+    #    banned_users = User.where(banned: true)
+    #    unconfirmed_users = User.where("confirmed_at IS NULL")
+    #    active_users = User.none_of(banned_users, unconfirmed_users)
+    def none_of(*queries)
+      raise ArgumentError, 'Called none_of() with no arguments.' if queries.none?
+      AlternativeBuilder.new(:negative, @scope, *queries).build
+    end
   end
 
-  # Returns a new relation, which includes results not matching any of the conditions
-  # passed as parameters. It's the negative version of <tt>#any_of</tt>.
-  #
-  # This will return all active users :
-  #
-  #    banned_users = User.where(banned: true)
-  #    unconfirmed_users = User.where("confirmed_at IS NULL")
-  #    active_users = User.none_of(banned_users, unconfirmed_users)
-  def none_of(*queries)
-    raise ArgumentError, 'Called none_of() with no arguments.' if queries.none?
-    AlternativeBuilder.new(:negative, self, *queries).build
+  module Deprecated
+    def any_of(*queries)
+      if Rails.version >= '4'
+        ActiveSupport::Deprecation.warn( "Calling #any_of directly is deprecated and will be removed in activerecord_any_of-1.2.\nPlease call it with #where : User.where.any_of(cond1, cond2)." )
+      end
+
+      raise ArgumentError, 'Called any_of() with no arguments.' if queries.none?
+      AlternativeBuilder.new(:positive, self, *queries).build
+    end
+
+    def none_of(*queries)
+      if Rails.version >= '4'
+        ActiveSupport::Deprecation.warn( "Calling #none_of directly is deprecated and will be removed in activerecord_any_of-1.2.\nPlease call it with #where : User.where.none_of(cond1, cond2)." )
+      end
+
+      raise ArgumentError, 'Called none_of() with no arguments.' if queries.none?
+      AlternativeBuilder.new(:negative, self, *queries).build
+    end
   end
 end
 
@@ -53,5 +75,6 @@ else
   end
 end
 
-ActiveRecord::Relation.send(:include, ActiverecordAnyOf)
+ActiveRecord::Relation.send(:include, ActiverecordAnyOf::Deprecated)
+ActiveRecord::Relation::WhereChain.send(:include, ActiverecordAnyOf::Chained) if Rails.version >= '4'
 ActiveRecord::Base.send(:extend, ActiverecordAnyOfDelegation)

--- a/test/activerecord_any_of_test.rb
+++ b/test/activerecord_any_of_test.rb
@@ -4,16 +4,21 @@ class ActiverecordAnyOfTest < ActiveSupport::TestCase
   fixtures :authors, :posts
 
   test 'finding with alternate conditions' do
-    assert_equal ['David', 'Mary'], Author.any_of({name: 'David'}, {name: 'Mary'}).map(&:name)
-    assert_equal ['David', 'Mary'], Author.any_of({name: 'David'}, ['name = ?', 'Mary']).map(&:name)
-
-    davids = Author.where(name: 'David')
-    assert_equal ['David', 'Mary', 'Bob'], Author.any_of(davids, ['name = ?', 'Mary'], {name: 'Bob'}).map(&:name)
-    assert_equal ['David', 'Mary', 'Bob'], Author.any_of(davids, "name = 'Mary'", {name: 'Bob', id: 3}).map(&:name)
-
     if Rails.version >= '4'
-      assert_equal ['David'], Author.where.not(name: 'Mary').any_of(davids, ['name = ?', 'Mary']).map(&:name)
+      assert_equal ['David', 'Mary'], Author.where.any_of({name: 'David'}, {name: 'Mary'}).map(&:name)
+      assert_equal ['David', 'Mary'], Author.where.any_of({name: 'David'}, ['name = ?', 'Mary']).map(&:name)
+
+      davids = Author.where(name: 'David')
+      assert_equal ['David', 'Mary', 'Bob'], Author.where.any_of(davids, ['name = ?', 'Mary'], {name: 'Bob'}).map(&:name)
+      assert_equal ['David', 'Mary', 'Bob'], Author.where.any_of(davids, "name = 'Mary'", {name: 'Bob', id: 3}).map(&:name)
+      assert_equal ['David'], Author.where.not(name: 'Mary').where.any_of(davids, ['name = ?', 'Mary']).map(&:name)
     else
+      assert_equal ['David', 'Mary'], Author.any_of({name: 'David'}, {name: 'Mary'}).map(&:name)
+      assert_equal ['David', 'Mary'], Author.any_of({name: 'David'}, ['name = ?', 'Mary']).map(&:name)
+
+      davids = Author.where(name: 'David')
+      assert_equal ['David', 'Mary', 'Bob'], Author.any_of(davids, ['name = ?', 'Mary'], {name: 'Bob'}).map(&:name)
+      assert_equal ['David', 'Mary', 'Bob'], Author.any_of(davids, "name = 'Mary'", {name: 'Bob', id: 3}).map(&:name)
       assert_equal ['David'], Author.where("name IS NOT 'Mary'").any_of(davids, ['name = ?', 'Mary']).map(&:name)
     end
   end
@@ -22,46 +27,84 @@ class ActiverecordAnyOfTest < ActiveSupport::TestCase
     david = Author.where(name: 'David').first
     welcome = david.posts.where(body: 'Such a lovely day')
     expected = ['Welcome to the weblog', 'So I was thinking']
-    assert_equal expected, david.posts.any_of(welcome, {type: 'SpecialPost'}).map(&:title)
+
+    if Rails.version >= '4'
+      assert_equal expected, david.posts.where.any_of(welcome, {type: 'SpecialPost'}).map(&:title)
+    else
+      assert_equal expected, david.posts.any_of(welcome, {type: 'SpecialPost'}).map(&:title)
+    end
   end
 
   test 'finding alternate dynamically with joined queries' do
     david = Author.where(posts: { title: 'Welcome to the weblog' }).joins(:posts)
     mary = Author.where(posts: { title: "eager loading with OR'd conditions" }).joins(:posts)
 
-    assert_equal ['David', 'Mary'], Author.any_of(david, mary).map(&:name)
+    if Rails.version >= '4'
+      assert_equal ['David', 'Mary'], Author.where.any_of(david, mary).map(&:name)
+    else
+      assert_equal ['David', 'Mary'], Author.any_of(david, mary).map(&:name)
+    end
 
     if Rails.version >= '4'
       david = Author.where(posts: { title: 'Welcome to the weblog' }).includes(:posts).references(:posts)
       mary = Author.where(posts: { title: "eager loading with OR'd conditions" }).includes(:posts).references(:posts)
+      assert_equal ['David', 'Mary'], Author.where.any_of(david, mary).map(&:name)
     else
       david = Author.where(posts: { title: 'Welcome to the weblog' }).includes(:posts)
       mary = Author.where(posts: { title: "eager loading with OR'd conditions" }).includes(:posts)
+      assert_equal ['David', 'Mary'], Author.any_of(david, mary).map(&:name)
     end
-
-    assert_equal ['David', 'Mary'], Author.any_of(david, mary).map(&:name)
   end
 
   test 'finding with alternate negative conditions' do
-    assert_equal ['Bob'], Author.none_of({name: 'David'}, {name: 'Mary'}).map(&:name)
+    if Rails.version >= '4'
+      assert_equal ['Bob'], Author.where.none_of({name: 'David'}, {name: 'Mary'}).map(&:name)
+    else
+      assert_equal ['Bob'], Author.none_of({name: 'David'}, {name: 'Mary'}).map(&:name)
+    end
   end
 
   test 'finding with alternate negative conditions on association' do
     david = Author.where(name: 'David').first
     welcome = david.posts.where(body: 'Such a lovely day')
     expected = ['sti comments', 'sti me', 'habtm sti test']
-    assert_equal expected, david.posts.none_of(welcome, {type: 'SpecialPost'}).map(&:title)
+
+    if Rails.version >= '4'
+      assert_equal expected, david.posts.where.none_of(welcome, {type: 'SpecialPost'}).map(&:title)
+    else
+      assert_equal expected, david.posts.none_of(welcome, {type: 'SpecialPost'}).map(&:title)
+    end
   end
 
   test 'calling #any_of with no argument raise exception' do
-    assert_raise(ArgumentError) { Author.any_of }
+    if Rails.version >= '4'
+      assert_raise(ArgumentError) { Author.where.any_of }
+    else
+      assert_raise(ArgumentError) { Author.any_of }
+    end
   end
 
   test 'calling #none_of with no argument raise exception' do
-    assert_raise(ArgumentError) { Author.none_of }
+    if Rails.version >= '4'
+      assert_raise(ArgumentError) { Author.where.none_of }
+    else
+      assert_raise(ArgumentError) { Author.none_of }
+    end
   end
 
   test 'calling #any_of after a wildcard query works' do
-    assert_equal ['David'], Author.where("name like '%av%'").any_of({name: 'David'}, {name: 'Mary'}).map(&:name)
+    if Rails.version >= '4'
+      assert_equal ['David'], Author.where("name like '%av%'").where.any_of({name: 'David'}, {name: 'Mary'}).map(&:name)
+    else
+      assert_equal ['David'], Author.where("name like '%av%'").any_of({name: 'David'}, {name: 'Mary'}).map(&:name)
+    end
+  end
+
+  if Rails.version >= '4'
+    test 'calling directly #any_of is deprecated in rails-4' do
+      assert_deprecated do
+        Author.any_of({name: 'David'}, {name: 'Mary'}).map(&:name)
+      end
+    end
   end
 end


### PR DESCRIPTION
In order to make it clear what is actually merged with `#any_of` is
conditions only, `#any_of` and `#none_of` now sits behind WhereChain :

``` ruby
inactive_users = User.where.any_of( { banned: true }, "confirmed_at = NULL" )
newsletter_users = User.where.none_of( inactive_users, { subscribed: false } )
```

Previous behavior has been kept for rails-3, as WhereChain does not
exist there. A deprecation warning has been added for rails-4, so that
users have time to migrate.

Close #7
