### PR TITLE
REFACTOR handle implicit hash parameters as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 1.2 - November 03, 2013
+
+* Automatically expand single parameter hash ([#13](https://github.com/oelmekki/activerecord_any_of/issues/13))
+
+  There was a lot of confusion about explit/implicit hash parameter notation,
+  with people expecting this to generate an OR query :
+
+    User.where.any_of(name: 'Doe', active: true)
+
+  This wouldn't work, since there is only one parameter, here : `{name: 'Doe', active: true}`,
+  so there's a single group of condition that is joined as a AND. To achieve
+  expected result, this should have been used :
+
+    User.where.any_of({name: 'Doe'}, {active: true})
+    
+  To be true to principle of least surprise, we now automatically expand
+  parameters consisting of a single Hash as a hash for each key, so first
+  query will indeed generate :
+
+    User.where.any_of(name: 'Doe', active: true)
+    # => SELECT * FROM users WHERE name = 'Doe' OR active = '1'
+
+
+  Grouping conditions can still be achieved using explicit curly brackets :
+
+    User.where.any_of({first_name: 'John', last_name: 'Doe'}, active: true)
+    # => SELECT * FROM users WHERE (first_name = 'John' AND last_name = 'Doe') OR active = '1'
+
+
+## 1.1 - August 31, 2013
+
+* use WhereChain in rails-4 ([#7](https://github.com/oelmekki/activerecord_any_of/issues/7))
+
+  `#any_of` and `#none_of` are now scoped behind WhereChain in rails-4 :
+
+      User.where.any_of({name: 'Doe'}, {active: true})
+
+  The point here is to make it clear we only handles *conditions*, not grouping or other
+  more query modifiers.
+
+
 ## 1.0.0 - June 22, 2013
 
 * handles joins in subqueries - ([#1](https://github.com/oelmekki/activerecord_any_of/issues/1))

--- a/lib/activerecord_any_of.rb
+++ b/lib/activerecord_any_of.rb
@@ -3,19 +3,32 @@ require 'activerecord_any_of/alternative_builder'
 module ActiverecordAnyOf
   module Chained
     # Returns a new relation, which includes results matching any of the conditions
-    # passed as parameters. You can think of it as a sql <tt>OR</tt> implementation.
+    # passed as parameters. You can think of it as a sql <tt>OR</tt> implementation :
     #
-    # Each #any_of parameter is the same set you would have passed to #where :
+    #    User.where.any_of(first_name: 'Joe', last_name: 'Joe')
+    #    # => SELECT * FROM users WHERE first_name = 'Joe' OR last_name = 'Joe'
     #
-    #    Client.any_of("orders_count = '2'", ["name = ?", 'Joe'], {email: 'joe@example.com'})
+    #
+    # You can separate sets of hash condition by explicitly group them as hashes :
+    #
+    #    User.where.any_of({first_name: 'John', last_name: 'Joe'}, {first_name: 'Simon', last_name: 'Joe'})
+    #    # => SELECT * FROM users WHERE ( first_name = 'John' AND last_name = 'Joe' ) OR ( first_name = 'Simon' AND last_name = 'Joe' )
+    #
+    #
+    # Each #any_of set is the same kind you would have passed to #where :
+    #
+    #    Client.where.any_of("orders_count = '2'", ["name = ?", 'Joe'], {email: 'joe@example.com'})
+    #
     #
     # You can as well pass #any_of to other relations :
     #
     #    Client.where("orders_count = '2'").any_of({ email: 'joe@example.com' }, { email: 'john@example.com' })
     #
+    #
     # And with associations :
     #
     #    User.find(1).posts.any_of({published: false}, "user_id IS NULL")
+    #
     #
     # The best part is that #any_of accepts other relations as parameter, to help compute
     # dynamic <tt>OR</tt> queries :

--- a/lib/activerecord_any_of/alternative_builder.rb
+++ b/lib/activerecord_any_of/alternative_builder.rb
@@ -1,6 +1,10 @@
 module ActiverecordAnyOf
   class AlternativeBuilder
     def initialize(match_type, context, *queries)
+      if Hash === queries.first and queries.count == 1
+        queries = queries.first.each_pair.map { |attr, predicate| Hash[attr, predicate] }
+      end
+
       @builder = match_type == :negative ? NegativeBuilder.new(context, *queries) : PositiveBuilder.new(context, *queries)
     end
 

--- a/test/activerecord_any_of_test.rb
+++ b/test/activerecord_any_of_test.rb
@@ -100,6 +100,10 @@ class ActiverecordAnyOfTest < ActiveSupport::TestCase
     end
   end
 
+  test 'calling #any_of with a single Hash as parameter expands it' do
+    assert_equal ['David', 'Mary'], Author.where.any_of(name: 'David', id: 2).map(&:name)
+  end
+
   if Rails.version >= '4'
     test 'calling directly #any_of is deprecated in rails-4' do
       assert_deprecated do


### PR DESCRIPTION
There was a lot of confusion about explit/implicit hash parameter notation,
with people expecting this to generate an OR query :

```
User.where.any_of(name: 'Doe', active: true)
```

This wouldn't work, since there is only one parameter, here : `{name: 'Doe', active: true}`,
so there's a single group of condition that is joined as a AND. To achieve
expected result, this should have been used :

```
User.where.any_of({name: 'Doe'}, {active: true})
```

To be true to principle of least surprise, we now automatically expand
parameters consisting of a single Hash as a hash for each key, so first
query will indeed generate :

```
User.where.any_of(name: 'Doe', active: true)
# => SELECT * FROM users WHERE name = 'Doe' OR active = '1'
```

Grouping conditions can still be achieved using explicit curly brackets :

```
User.where.any_of({first_name: 'John', last_name: 'Doe'}, active: true)
# => SELECT * FROM users WHERE (first_name = 'John' AND last_name = 'Doe') OR active = '1'
```

Fix #13
