### PR TITLE
FIX prepared statements messing up

### DIFF
--- a/lib/activerecord_any_of/alternative_builder.rb
+++ b/lib/activerecord_any_of/alternative_builder.rb
@@ -71,7 +71,7 @@ module ActiverecordAnyOf
 
         def with_statement_cache
           if queries && queries_bind_values.any?
-            relation = where([queries.reduce(:or).to_sql, *queries_bind_values.map { |v| v[1] }])
+            relation = where([queries.reduce(:or).to_sql.gsub(/\=\ \$\d/, "= ?"), *queries_bind_values.map { |v| v[1] }])
           else
             relation = where(queries.reduce(:or).to_sql)
           end

--- a/lib/activerecord_any_of/alternative_builder.rb
+++ b/lib/activerecord_any_of/alternative_builder.rb
@@ -64,6 +64,12 @@ module ActiverecordAnyOf
 
           relation
         end
+
+        def unprepare_query(query)
+          query.gsub(/((?<!\\)'.*?(?<!\\)'|(?<!\\)".*?(?<!\\)")|(\=\ \$\d)/) do |match|
+            $2 and $2.gsub(/\=\ \$\d/, "= ?") or match
+          end
+        end
     end
 
     class PositiveBuilder < Builder
@@ -71,7 +77,7 @@ module ActiverecordAnyOf
 
         def with_statement_cache
           if queries && queries_bind_values.any?
-            relation = where([queries.reduce(:or).to_sql.gsub(/\=\ \$\d/, "= ?"), *queries_bind_values.map { |v| v[1] }])
+            relation = where([unprepare_query(queries.reduce(:or).to_sql), *queries_bind_values.map { |v| v[1] }])
           else
             relation = where(queries.reduce(:or).to_sql)
           end
@@ -91,13 +97,13 @@ module ActiverecordAnyOf
         def with_statement_cache
           if ActiveRecord::VERSION::MAJOR >= 4
             if queries && queries_bind_values.any?
-              relation = where.not([queries.reduce(:or).to_sql, *queries_bind_values.map { |v| v[1] }])
+              relation = where.not([unprepare_query(queries.reduce(:or).to_sql), *queries_bind_values.map { |v| v[1] }])
             else
               relation = where.not(queries.reduce(:or).to_sql)
             end
           else
             if queries && queries_bind_values.any?
-              relation = where([Arel::Nodes::Not.new(queries.reduce(:or)).to_sql, *queries_bind_values.map { |v| v[1] }])
+              relation = where([unprepare_query(Arel::Nodes::Not.new(queries.reduce(:or)).to_sql), *queries_bind_values.map { |v| v[1] }])
             else
               relation = where(Arel::Nodes::Not.new(queries.reduce(:or)).to_sql)
             end

--- a/spec/activerecord_any_of_spec.rb
+++ b/spec/activerecord_any_of_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe ActiverecordAnyOf do
-  fixtures :authors, :posts
+  fixtures :authors, :posts, :users
 
   describe 'finding with alternate conditions' do
     let(:davids) { Author.where(name: "David") }
@@ -56,6 +56,20 @@ describe ActiverecordAnyOf do
       expect(david.posts.where.any_of(welcome, {type: 'SpecialPost'}).map(&:title)).to match_array(expected)
     else
       expect(david.posts.any_of(welcome, {type: 'SpecialPost'}).map(&:title)).to match_array(expected)
+    end
+  end
+
+  it 'finds with combined polymorphic associations' do
+    company = Company.create!
+    university = University.create!
+
+    company.users << users(:ezra)
+    university.users << users(:aria)
+
+    if ActiveRecord::VERSION::MAJOR >= 4
+      expect(User.where.any_of(company.users, university.users)).to match_array([users(:ezra), users(:aria)])
+    else
+      expect(User.any_of(company.users, university.users)).to match_array([users(:ezra), users(:aria)])
     end
   end
 

--- a/spec/activerecord_any_of_spec.rb
+++ b/spec/activerecord_any_of_spec.rb
@@ -67,9 +67,25 @@ describe ActiverecordAnyOf do
     university.users << users(:aria)
 
     if ActiveRecord::VERSION::MAJOR >= 4
-      expect(User.where.any_of(company.users, university.users)).to match_array([users(:ezra), users(:aria)])
+      expect(User.where.any_of(company.users, university.users)).to match_array(users(:ezra, :aria))
     else
-      expect(User.any_of(company.users, university.users)).to match_array([users(:ezra), users(:aria)])
+      expect(User.any_of(company.users, university.users)).to match_array(users(:ezra, :aria))
+    end
+  end
+
+  it 'finds with more than 2 combined polymorphic associations' do
+    company = Company.create!
+    university = University.create!
+    company2 = Company.create!
+
+    company.users << users(:ezra)
+    university.users << users(:aria)
+    company2.users << users(:james)
+
+    if ActiveRecord::VERSION::MAJOR >= 4
+      expect(User.where.any_of(company.users, university.users, company2.users)).to match_array(users(:ezra, :aria, :james))
+    else
+      expect(User.any_of(company.users, university.users, company2.users)).to match_array(users(:ezra, :aria, :james))
     end
   end
 

--- a/spec/activerecord_any_of_spec.rb
+++ b/spec/activerecord_any_of_spec.rb
@@ -74,12 +74,22 @@ describe ActiverecordAnyOf do
   end
 
   it 'finds alternatives with combined has_many associations' do
+    david, mary = authors(:david, :mary)
+
+    if ActiveRecord::VERSION::MAJOR >= 4
+      expect(Post.where.any_of(david.posts, mary.posts)).to match_array(david.posts + mary.posts)
+    else
+      expect(Post.any_of(david.posts, mary.posts)).to match_array(david.posts + mary.posts)
+    end
+  end
+
+  it 'finds alternatives with more than 2 combined has_many associations' do
     david, mary, bob = authors(:david, :mary, :bob)
 
     if ActiveRecord::VERSION::MAJOR >= 4
-      expect(Post.where.any_of(david.posts, mary.posts)).to match_array(david.posts + mary.posts + bob.posts)
+      expect(Post.where.any_of(david.posts, mary.posts, bob.posts)).to match_array(david.posts + mary.posts + bob.posts)
     else
-      expect(Post.any_of(david.posts, mary.posts)).to match_array(david.posts + mary.posts + bob.posts)
+      expect(Post.any_of(david.posts, mary.posts, bob.posts)).to match_array(david.posts + mary.posts + bob.posts)
     end
   end
 

--- a/spec/activerecord_any_of_spec.rb
+++ b/spec/activerecord_any_of_spec.rb
@@ -73,6 +73,16 @@ describe ActiverecordAnyOf do
     end
   end
 
+  it 'finds alternatives with combined has_many associations' do
+    david, mary, bob = authors(:david, :mary, :bob)
+
+    if ActiveRecord::VERSION::MAJOR >= 4
+      expect(Post.where.any_of(david.posts, mary.posts)).to match_array(david.posts + mary.posts + bob.posts)
+    else
+      expect(Post.any_of(david.posts, mary.posts)).to match_array(david.posts + mary.posts + bob.posts)
+    end
+  end
+
   describe 'finding alternate dynamically with joined queries' do
     it "matches combined AR relations with joins" do
       david = Author.where(posts: { title: 'Welcome to the weblog' }).joins(:posts)

--- a/spec/db/schema.rb
+++ b/spec/db/schema.rb
@@ -13,4 +13,21 @@ ActiveRecord::Schema.define do
     t.datetime :created_at
     t.datetime :updated_at
   end
+
+  create_table :companies do |t|
+    t.string :name
+  end
+
+  create_table :universities do |t|
+    t.string :name
+  end
+
+  create_table :memberships do |t|
+    t.references :organization, polymorphic: true
+    t.references :user
+  end
+
+  create_table :users do |t|
+    t.string  :name
+  end
 end

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -1,0 +1,6 @@
+ezra:
+  id: 1
+  name: "Ezra"
+aria:
+  id: 2
+  name: "Aria"

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -4,3 +4,6 @@ ezra:
 aria:
   id: 2
   name: "Aria"
+james:
+  id: 3
+  name: "James"

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -12,3 +12,23 @@ end
 class StiPost < Post
 end
 
+class User < ActiveRecord::Base
+  has_many :memberships
+  has_many :companies, through: :memberships, source: :organization, source_type: "Company"
+  has_many :universities, through: :memberships, source: :organization, source_type: "University"
+end
+
+class Membership < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :organization, polymorphic: true
+end
+
+class Company < ActiveRecord::Base
+  has_many :memberships, as: :organization
+  has_many :users, through: :memberships
+end
+
+class University < ActiveRecord::Base
+  has_many :memberships, as: :organization
+  has_many :users, through: :memberships
+end


### PR DESCRIPTION
When using arel level OR'ing, prepared statement and concataned
untouched. This is a problem because wildcards will use the same number
($1, $2, etc) in each statement, leading to a mismatch between expected
and provided statements.

Fixed by parsing strings and remapping wildcards.

Needs #19 

Close #15
