### PR TITLE
FIX joins unicity

### DIFF
--- a/lib/activerecord_any_of/alternative_builder.rb
+++ b/lib/activerecord_any_of/alternative_builder.rb
@@ -43,7 +43,17 @@ module ActiverecordAnyOf
         end
 
         def uniq_queries_joins_values
-          @uniq_queries_joins_values ||= queries_joins_values.each { |tables| tables.uniq }
+          @uniq_queries_joins_values ||= begin
+            { includes: [], joins: [], references: [] }.tap do |values|
+              queries_joins_values.each do |join_type, statements|
+                if Symbol === statements.first or String === statements.first
+                  values[ join_type ] = statements.uniq
+                else
+                  values[ join_type ] = statements.uniq( &:to_sql )
+                end
+              end
+            end
+          end
         end
 
         def method_missing(method_name, *args, &block)


### PR DESCRIPTION
On rails-3, joins statements from different queries would not be made
properly unique, which caused sql errors.

Turned out [uniq queries method was
bogus](https://github.com/oelmekki/activerecord_any_of/blob/ee7f010382772ffa7c232f2a489cfcbcb639cbd4/lib/activerecord_any_of/alternative_builder.rb#L46)
and did not actually reduce queries array, it only worked on rails-4
because active_record was checking for duplicate itself later.
