### PR TITLE
FIX using all or none

### DIFF
--- a/lib/activerecord_any_of/alternative_builder.rb
+++ b/lib/activerecord_any_of/alternative_builder.rb
@@ -38,6 +38,7 @@ module ActiverecordAnyOf
             queries_joins_values[:includes].concat(query.includes_values) if query.includes_values.any?
             queries_joins_values[:joins].concat(query.joins_values) if query.joins_values.any?
             queries_joins_values[:references].concat(query.references_values) if ActiveRecord::VERSION::MAJOR >= 4 && query.references_values.any?
+            query = query.where( query.to_sql.present? ? "1=1" : "0=1" ) if query.arel.constraints.empty?
             query.arel.constraints.reduce(:and)
           end
         end

--- a/spec/activerecord_any_of_spec.rb
+++ b/spec/activerecord_any_of_spec.rb
@@ -154,6 +154,30 @@ describe ActiverecordAnyOf do
     end
   end
 
+  describe 'calling #any_of with #all' do
+    it 'returns all records of relation' do
+      davids = Author.where(name: 'David')
+      david, mary, bob = authors(:david, :mary, :bob)
+
+      if ActiveRecord::VERSION::MAJOR >= 4
+        expect(Author.where.any_of(Author.all, davids)).to match_array([david, mary, bob])
+      else
+        expect(Author.any_of(Author.all, davids)).to match_array([david, mary, bob])
+      end
+    end
+  end
+
+  describe 'calling #any_of with #none' do
+    it 'does not consider #none' do
+      davids = Author.where(name: 'David')
+
+      # none was implemented in rails 4
+      if ActiveRecord::VERSION::MAJOR >= 4
+        expect(Author.where.any_of(Author.none, davids)).to match_array(davids)
+      end
+    end
+  end
+
   it 'calling #any_of with no argument raise exception' do
     if ActiveRecord::VERSION::MAJOR >= 4
       expect { Author.where.any_of }.to raise_exception(ArgumentError)


### PR DESCRIPTION
When passing a query with `Model.all` or `Model.none`, we get a
`NoMethodError: undefined method 'or' for nil:NilClass` due to not
constraints being set by arel.
Fixed by modifying original query to use `where('0=1')` or
`where('1=1)`.

Rel 22
