### PR TITLE
Fix long prepared queries

### DIFF
--- a/lib/activerecord_any_of/alternative_builder.rb
+++ b/lib/activerecord_any_of/alternative_builder.rb
@@ -76,8 +76,8 @@ module ActiverecordAnyOf
         end
 
         def unprepare_query(query)
-          query.gsub(/((?<!\\)'.*?(?<!\\)'|(?<!\\)".*?(?<!\\)")|(\=\ \$\d)/) do |match|
-            $2 and $2.gsub(/\=\ \$\d/, "= ?") or match
+          query.gsub(/((?<!\\)'.*?(?<!\\)'|(?<!\\)".*?(?<!\\)")|(\=\ \$\d+)/) do |match|
+            $2 and $2.gsub(/\=\ \$\d+/, "= ?") or match
           end
         end
     end

--- a/spec/activerecord_any_of_spec.rb
+++ b/spec/activerecord_any_of_spec.rb
@@ -186,6 +186,33 @@ describe ActiverecordAnyOf do
     end
   end
 
+  it "does not fail on hudge number for bind values" do
+    conditions = [
+      { name: 'Mary' },
+      { name: 'David' },
+      { name: 'David1' },
+      { name: 'David2' },
+      { name: 'David3' },
+      { name: 'David4' },
+      { name: 'David5' },
+      { name: 'David6' },
+      { name: 'David7' },
+      { name: 'David8' },
+      { name: 'David9' },
+      { name: 'David10' },
+      { name: 'David11' },
+      { name: 'David12' },
+      { name: 'David13' },
+      { name: 'David14' }
+    ]
+
+    if ActiveRecord::VERSION::MAJOR >= 4
+      expect(Author.where.any_of(*conditions)).to match_array(authors(:david, :mary))
+    else
+      expect(Author.any_of(*conditions)).to match_array(authors(:david, :mary))
+    end
+  end
+
   if ActiveRecord::VERSION::MAJOR >= 4
     it 'calling directly #any_of is deprecated in rails-4' do
       allow(ActiveSupport::Deprecation).to receive(:warn)


### PR DESCRIPTION
There is a strange behaviour on queries with more than 9 bind values inside queries, it replaces 

```
$1 => ?
```
However when you reach something like this it corrupts the resulting sql:

```
$12 => ?2
```