### PR TITLE
Fix hash includes

### DIFF
--- a/lib/activerecord_any_of/alternative_builder.rb
+++ b/lib/activerecord_any_of/alternative_builder.rb
@@ -46,10 +46,10 @@ module ActiverecordAnyOf
           @uniq_queries_joins_values ||= begin
             { includes: [], joins: [], references: [] }.tap do |values|
               queries_joins_values.each do |join_type, statements|
-                if Symbol === statements.first or String === statements.first
-                  values[ join_type ] = statements.uniq
-                else
+                if statements.first.respond_to?(:to_sql)
                   values[ join_type ] = statements.uniq( &:to_sql )
+                else
+                  values[ join_type ] = statements.uniq
                 end
               end
             end

--- a/spec/activerecord_any_of_spec.rb
+++ b/spec/activerecord_any_of_spec.rb
@@ -154,7 +154,7 @@ describe ActiverecordAnyOf do
     end
   end
 
-  it 'calling #any_of with no argument raise exception' do
+  it 'calling #any_of with no argument raises exception' do
     if ActiveRecord::VERSION::MAJOR >= 4
       expect { Author.where.any_of }.to raise_exception(ArgumentError)
     else
@@ -162,7 +162,7 @@ describe ActiverecordAnyOf do
     end
   end
 
-  it 'calling #none_of with no argument raise exception' do
+  it 'calling #none_of with no argument raises exception' do
     if ActiveRecord::VERSION::MAJOR >= 4
       expect { Author.where.none_of }.to raise_exception(ArgumentError)
     else

--- a/spec/activerecord_any_of_spec.rb
+++ b/spec/activerecord_any_of_spec.rb
@@ -170,6 +170,16 @@ describe ActiverecordAnyOf do
     end
   end
 
+  it 'calling #any_of after including via a hash does not raise an exception' do
+    if ActiveRecord::VERSION::MAJOR >= 4
+      expect { User.includes(memberships: :companies).where.any_of(user_id: 1, company_id: 1) }.
+        to_not raise_exception
+    else
+      expect { User.includes(memberships: :companies).any_of(user_id: 1, company_id: 1) }.
+        to_not raise_exception
+    end
+  end
+
   it 'calling #any_of after a wildcard query works' do
     if ActiveRecord::VERSION::MAJOR >= 4
       expect(Author.where("name like '%av%'").where.any_of({name: 'David'}, {name: 'Mary'})).to match_array([authors(:david)])


### PR DESCRIPTION
Previously, doing something like `User.includes(memberships: :companies).where.any_of(...)` would result in a `NoMethodError` from calling `to_sql` on a `Hash`.

Went with `respond_to?` over continuing to chain type checks together.