### PR TITLE
ADD rails-5 support

### DIFF
--- a/activerecord_any_of.gemspec
+++ b/activerecord_any_of.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "activerecord", ">= 3.2.13", '< 5'
+  s.add_dependency "activerecord", ">= 3.2.13", '< 6'
 
   s.add_development_dependency 'rspec-rails', '~> 2.12'
   s.add_development_dependency 'rake', '~> 10'

--- a/lib/activerecord_any_of/alternative_builder.rb
+++ b/lib/activerecord_any_of/alternative_builder.rb
@@ -34,11 +34,22 @@ module ActiverecordAnyOf
               query = where(*query)
             end
 
-            self.queries_bind_values += query.bind_values if query.bind_values.any?
+            if ( bound = bind_values_for( query ) ).any?
+              self.queries_bind_values += bound
+            end
+
             queries_joins_values[:includes].concat(query.includes_values) if query.includes_values.any?
             queries_joins_values[:joins].concat(query.joins_values) if query.joins_values.any?
             queries_joins_values[:references].concat(query.references_values) if ActiveRecord::VERSION::MAJOR >= 4 && query.references_values.any?
             query.arel.constraints.reduce(:and)
+          end
+        end
+
+        def bind_values_for( query )
+          if ActiveRecord::VERSION::MAJOR >= 5
+            query.bound_attributes.map { |attr| [ attr.name, attr.value ] }
+          else
+            query.bind_values
           end
         end
 


### PR DESCRIPTION
Allow to use activerecord_any_of with rails-5.

The only change is that `Relation#bind_values` is now
`Relation#bound_attributes`.